### PR TITLE
Revert "M1 Macでも開発できるようにしたい！！！！"

### DIFF
--- a/.github/workflows/publish-bungeesemaphore-redis-dev.yml
+++ b/.github/workflows/publish-bungeesemaphore-redis-dev.yml
@@ -41,7 +41,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./bungeesemaphore-redis-dev
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: |

--- a/.github/workflows/publish-seichiassist-builder.yml
+++ b/.github/workflows/publish-seichiassist-builder.yml
@@ -41,7 +41,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./seichiassist-builder
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: |

--- a/.github/workflows/publish-seichiassist-runner.yml
+++ b/.github/workflows/publish-seichiassist-runner.yml
@@ -41,7 +41,6 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: ./seichiassist-runner
-          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           builder: ${{ steps.buildx.outputs.name }}
           push: true
           tags: |


### PR DESCRIPTION
Reverts GiganticMinecraft/dockers#14

```
Run docker/build-push-action@v3
Docker info
Buildx version
/usr/bin/docker buildx build --cache-from type=gha --cache-to type=gha,mode=max --iidfile /tmp/docker-build-push-3I025P/iidfile --platform linux/amd64,linux/arm64,linux/arm64/v8 --tag ghcr.io/giganticminecraft/seichiassist-builder:latest --tag ghcr.io/giganticminecraft/seichiassist-builder:6e75a2f --metadata-file /tmp/docker-build-push-3I025P/metadata-file --push ./seichiassist-builder
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 1.05kB done
#1 DONE 0.0s
#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s
#3 [linux/arm64 internal] load metadata for docker.io/library/adoptopenjdk:8u282-b08-jdk-openj9-0.24.0
#3 ...
#4 [auth] library/adoptopenjdk:pull token for registry-1.docker.io
#4 DONE 0.0s
#5 [linux/amd64 internal] load metadata for docker.io/library/adoptopenjdk:8u282-b08-jdk-openj9-0.24.0
#5 ERROR: ref buildkit/1/index-sha256:c8c8c7b0f02c762b41a1542ecb23b8c63ac936d[116](https://github.com/GiganticMinecraft/dockers/runs/7274601567?check_suite_focus=true#step:6:119)2352a2d12bef2b52386621 locked for 409.984872ms (since 2022-07-11 01:13:15.433947037 +0000 UTC m=+3.068230647): unavailable
#3 [linux/arm64 internal] load metadata for docker.io/library/adoptopenjdk:8u282-b08-jdk-openj9-0.24.0
#3 ERROR: no match for platform in manifest sha256:c8c8c7b0f02c762b41a1542ecb23b8c63ac936d1162352a2d12bef2b52386621: not found
------
 > [linux/arm64 internal] load metadata for docker.io/library/adoptopenjdk:8u282-b08-jdk-openj9-0.24.0:
------
------
 > [linux/amd64 internal] load metadata for docker.io/library/adoptopenjdk:8u282-b08-jdk-openj9-0.24.0:
------
Dockerfile:1
--------------------
   1 | >>> FROM adoptopenjdk:8u282-b08-jdk-openj9-0.24.0
   2 |     
   3 |     # sbt をインストールする (https://www.scala-sbt.org/1.x/docs/ja/Installing-sbt-on-Linux.html)
--------------------
error: failed to solve: adoptopenjdk:8u282-b08-jdk-openj9-0.24.0: no match for platform in manifest sha256:c8c8c7b0f02c762b41a1542ecb23b8c63ac936d1162352a2d12bef2b52386621: not found
Error: buildx failed with: error: failed to solve: adoptopenjdk:8u282-b08-jdk-openj9-0.24.0: no match for platform in manifest sha256:c8c8c7b0f02c762b41a1542ecb23b8c63ac936d1162352a2d12bef2b52386621: not found
```